### PR TITLE
chore: add the git version into the PostgreSQL version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,6 +135,7 @@ RUN set -eux ; \
 		--with-systemd \
 		--with-selinux \
 		--with-zstd \
+		--with-extra-version=-$(git rev-parse --short HEAD) \
 		--datarootdir=/usr/share/ \
 		--infodir=/usr/share/info \
 		--localstatedir=/var \


### PR DESCRIPTION
When running `SELECT version();` we now show the git commit hash