### PR TITLE
Revert "chore: pin barman version to 3.11.1 (#64)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -199,7 +199,7 @@ RUN set -xe; \
 		python3-setuptools \
 	; \
 	pip3 install --break-system-packages --upgrade pip; \
-	pip3 install --break-system-packages barman[cloud,azure,snappy,google]==3.11.1; \
+	pip3 install --break-system-packages barman[cloud,azure,snappy,google]; \
 	# TODO: Remove build deps once barman unpins the snappy version or
 	# https://github.com/EnterpriseDB/barman/issues/905 is completed
 	apt-get remove -y --purge --autoremove \


### PR DESCRIPTION
This reverts commit f5c51b28bff8d452807b2224af5d58f2fd003bb0.