### PR TITLE
ci(security): reduce the workflow permissions to read-all

### DIFF
--- a/.github/workflows/build-commitfest.yml
+++ b/.github/workflows/build-commitfest.yml
@@ -15,6 +15,8 @@ defaults:
     # default failure handling for shell scripts in 'run' steps
     shell: 'bash -Eeuo pipefail -x {0}'
 
+permissions: read-all
+
 jobs:
   build-pg:
     name: Build the patch for PostgreSQL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ defaults:
     # default failure handling for shell scripts in 'run' steps
     shell: 'bash -Eeuo pipefail -x {0}'
 
+permissions: read-all
+
 jobs:
   build-pg:
     name: Build generic PostgreSQL image from sources

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -19,6 +19,8 @@ defaults:
     # default failure handling for shell scripts in 'run' steps
     shell: 'bash -Eeuo pipefail -x {0}'
 
+permissions: read-all
+
 jobs:
   build-pg:
     name: Build the Trunk of PostgreSQL
@@ -87,6 +89,8 @@ jobs:
     needs:
       - build-pg
     uses: ./.github/workflows/reusable-e2e.yml
+    permissions:
+      packages: write
     with:
       postgres_img: ${{ needs.build-pg.outputs.pg_image }}
       major_version: ${{ needs.build-pg.outputs.pg_major }}

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -37,10 +37,28 @@ defaults:
     # default failure handling for shell scripts in 'run' steps
     shell: 'bash -Eeuo pipefail -x {0}'
 
+permissions:
+  actions: none
+  attestations: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  models: none
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  security-events: none
+  statuses: none
+
 jobs:
   e2e-local:
     name: Run E2E on local executors
     runs-on: ubuntu-24.04
+    permissions:
+      packages: write
     env:
       TEST_DEPTH: ${{ inputs.test_depth }}
       FEATURE_TYPE: ${{ inputs.feature_type }}

--- a/.github/workflows/run-e2e-test.yml
+++ b/.github/workflows/run-e2e-test.yml
@@ -19,6 +19,8 @@ on:
         description: 'E2E feature type filter. See https://github.com/cloudnative-pg/cloudnative-pg/blob/main/contribute/e2e_testing_environment/README.md#using-feature-type-test-selectionfilter'
         required: false
 
+permissions: read-all
+
 jobs:
   evaluate-env:
     name: Evaluate input env variables
@@ -62,6 +64,8 @@ jobs:
     needs:
       - evaluate-env
     uses: ./.github/workflows/reusable-e2e.yml
+    permissions:
+      packages: write
     with:
       postgres_img: ${{ needs.evaluate-env.outputs.pg_image }}
       major_version: ${{ needs.evaluate-env.outputs.pg_major }}


### PR DESCRIPTION
By default all the workflows should have read-all permissions and any extra
 permission required should be added explicitly per job.

Closes #84 