### PR TITLE
chore: remove barman-cloud

### DIFF
--- a/.github/workflows/build-commitfest.yml
+++ b/.github/workflows/build-commitfest.yml
@@ -100,7 +100,7 @@ jobs:
           commitFestURL="https://commitfest.postgresql.org/patch/${commitFestPatchID}"
           images="${{ needs.build-pg.outputs.images }}"
           images_list="$(echo $images | tr ' ' '\n' | sed 's/^/https:\/\//')"
-          standardImage="$(echo $images | tr ' ' '\n' | grep standard)"
+          minimalImage="$(echo $images | tr ' ' '\n' | grep minimal)"
 
           echo "# Commitfest Image Build summary" >> $GITHUB_STEP_SUMMARY
           echo "**Commitfest Patch URL**: [$commitFestPatchID]($commitFestURL)" >> $GITHUB_STEP_SUMMARY
@@ -116,7 +116,7 @@ jobs:
           echo "metadata:" >> $GITHUB_STEP_SUMMARY
           echo "  name: commitfest-$commitFestPatchID" >> $GITHUB_STEP_SUMMARY
           echo "spec:" >> $GITHUB_STEP_SUMMARY
-          echo "  imageName: $standardImage" >> $GITHUB_STEP_SUMMARY
+          echo "  imageName: $minimalImage" >> $GITHUB_STEP_SUMMARY
           echo "  instances: 3" >> $GITHUB_STEP_SUMMARY
           echo "  storage:" >> $GITHUB_STEP_SUMMARY
           echo "    size: 1Gi" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,13 +98,13 @@ jobs:
           pg_major="${{ needs.build-pg.outputs.pg_major }}"
           images="${{ needs.build-pg.outputs.images }}"
           images_list="$(echo $images | tr ' ' '\n' | sed 's/^/https:\/\//')"
-          standardImage="$(echo $images | tr ' ' '\n' | grep standard)"
+          minimalImage="$(echo $images | tr ' ' '\n' | grep minimal)"
 
           echo "# PostgreSQL Image Build summary" >> $GITHUB_STEP_SUMMARY
           echo "Here's the list of Container Images that have been built:" >> $GITHUB_STEP_SUMMARY
           echo "$images_list" >> $GITHUB_STEP_SUMMARY
 
-          echo "## CloudNativePG Cluster definition (example using the standard image)" >> $GITHUB_STEP_SUMMARY
+          echo "## CloudNativePG Cluster definition (example using the minimal image)" >> $GITHUB_STEP_SUMMARY
           echo "You can create a cluster in CloudNativePG running this image:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`sh" >> $GITHUB_STEP_SUMMARY
           echo "(cat <<EOF" >> $GITHUB_STEP_SUMMARY
@@ -113,7 +113,7 @@ jobs:
           echo "metadata:" >> $GITHUB_STEP_SUMMARY
           echo "  name: pg-$pg_major-build" >> $GITHUB_STEP_SUMMARY
           echo "spec:" >> $GITHUB_STEP_SUMMARY
-          echo "  imageName: $standardImage" >> $GITHUB_STEP_SUMMARY
+          echo "  imageName: $minimalImage" >> $GITHUB_STEP_SUMMARY
           echo "  instances: 3" >> $GITHUB_STEP_SUMMARY
           echo "  storage:" >> $GITHUB_STEP_SUMMARY
           echo "    size: 1Gi" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Generated images
       id: images
       run: |
-        echo "PG_IMAGE=$(echo '${{ steps.build.outputs.metadata }}' | jq -r '.["standard"].["image.name"]' | grep -oP '[^,]*\d{12}[^,]*')" >> $GITHUB_ENV
+        echo "PG_IMAGE=$(echo '${{ steps.build.outputs.metadata }}' | jq -r '.["minimal"].["image.name"]' | grep -oP '[^,]*\d{12}[^,]*')" >> $GITHUB_ENV
 
   call-reusable-e2e:
     if: github.event_name == 'schedule'

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -152,7 +152,11 @@ jobs:
           sed -i '/DefaultImageName *=/s@".*"@"'"${{ inputs.postgres_img }}"'"@' pkg/versions/versions.go
 
           # Exlude backup/recovery tests
-          echo "FEATURE_TYPE=${{ env.FEATURE_TYPE }},!backup-restore" >> $GITHUB_ENV
+          if [ -z "${{ env.FEATURE_TYPE }}" ]; then
+            echo "FEATURE_TYPE=!backup-restore" >> $GITHUB_ENV
+          else
+            echo "FEATURE_TYPE=${{ env.FEATURE_TYPE }},!backup-restore" >> $GITHUB_ENV
+          fi
 
       - name: Run Kind End-to-End tests
         run: make e2e-test-kind

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -146,10 +146,13 @@ jobs:
           docker push $E2E_PRE_ROLLING_UPDATE_IMG
           echo "E2E_PRE_ROLLING_UPDATE_IMG=$E2E_PRE_ROLLING_UPDATE_IMG" >> $GITHUB_ENV
 
-      - name: Setting up default versions
+      - name: Setting up defaults
         run: |
           # Update pkg/versions/versions.go
           sed -i '/DefaultImageName *=/s@".*"@"'"${{ inputs.postgres_img }}"'"@' pkg/versions/versions.go
+
+          # Exlude backup/recovery tests
+          FEATURE_TYPE="${{ env.FEATURE_TYPE }},!backup-restore"
 
       - name: Run Kind End-to-End tests
         run: make e2e-test-kind

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -152,7 +152,7 @@ jobs:
           sed -i '/DefaultImageName *=/s@".*"@"'"${{ inputs.postgres_img }}"'"@' pkg/versions/versions.go
 
           # Exlude backup/recovery tests
-          FEATURE_TYPE="${{ env.FEATURE_TYPE }},!backup-restore"
+          echo "FEATURE_TYPE=${{ env.FEATURE_TYPE }},!backup-restore" >> $GITHUB_ENV
 
       - name: Run Kind End-to-End tests
         run: make e2e-test-kind

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN apt-get update && \
 		gnupg \
 		dirmngr \
 		ca-certificates \
-		locales-all \
 		ssl-cert \
 		libnss-wrapper \
 		libgssapi-krb5-2 \
@@ -127,16 +126,9 @@ FROM build-layer AS standard
 #	make install USE_PGXS=1 PG_CONFIG=/usr/lib/postgresql/$PG_MAJOR/bin/pg_config && \
 #	rm -rf /usr/src/pgaudit
 
-# Install barman-cloud
+# Install all locales
 RUN apt-get update && \
-	/usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y && \
-	apt-get install -y --no-install-recommends \
-		python3-pip \
-		python3-psycopg2 \
-		python3-setuptools \
-	&& \
-	pip3 install --break-system-packages --upgrade pip && \
-	pip3 install --break-system-packages barman[cloud,azure,google,snappy,zstandard,lz4]==3.13.2
+	apt-get install -y --no-install-recommends locales-all
 
 RUN apt-get purge -y --auto-remove $(cat /build-deps.txt) && \
 	rm -rf /var/lib/apt/lists/* /var/cache/* /var/log/*

--- a/defaults.json
+++ b/defaults.json
@@ -1,5 +1,5 @@
 {
-  "PG_IMAGE": "ghcr.io/cloudnative-pg/postgresql-trunk:18-standard-bookworm",
+  "PG_IMAGE": "ghcr.io/cloudnative-pg/postgresql-trunk:18-minimal-bookworm",
   "PG_MAJOR": 18,
   "CNPG_BRANCH": "main",
   "TEST_DEPTH": 4,


### PR DESCRIPTION
Removing barman-cloud from the images. 
Moving locales-all to `-standard` images only.
Changing the workflow that runs the E2Es to use `-minimal` images by default, excluding tests that require backup & restore capabilities.

Closes #86 