### PR TITLE
chore: remove workaround for major-upgrade E2Es

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -148,9 +148,6 @@ jobs:
 
       - name: Setting up defaults
         run: |
-          # Update pkg/versions/versions.go
-          sed -i '/DefaultImageName *=/s@".*"@"'"${{ inputs.postgres_img }}"'"@' pkg/versions/versions.go
-
           # Exlude backup/recovery tests
           if [ -z "${{ env.FEATURE_TYPE }}" ]; then
             echo "FEATURE_TYPE=!backup-restore" >> $GITHUB_ENV


### PR DESCRIPTION
Now that support for beta versions in major-upgrade E2Es has been added in https://github.com/cloudnative-pg/cloudnative-pg/pull/8036, this workaround to set the latest DefaultImage can be removed.