### PR TITLE
fix: build PostGIS from the stable-3.6 branch

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -91,7 +91,7 @@ jobs:
         echo "PG_IMAGE=$(echo "${BUILD_METADATA}" | jq -r '.["minimal"].["image.name"]' | grep -oP '[^,]*\d{12}[^,]*')" >> $GITHUB_ENV
 
   call-reusable-e2e:
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     needs:
       - build-pg
     uses: ./.github/workflows/reusable-e2e.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,7 @@ USER 26
 FROM standard AS postgis
 USER root
 ARG POSTGIS_REPO=https://github.com/postgis/postgis.git
-ARG POSTGIS_BRANCH=master
+ARG POSTGIS_BRANCH=stable-3.6
 
 RUN apt-get update && \
 	apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Build PostGIS using `stable-3.6` instead of `main`.
The `main` branch has moved the `address_standardizer` extension into a separate https://github.com/postgis/address_standardizer repository. 

When building `address_standardizer` from its new repository, the library is being created as `address_standardizer.so` , while in  `v18` packages the extension was called `address_standardizer-3.so`.

This makes pg_upgrade complain with:
```
could not load library "address_standardizer-3": ERROR: could not access file "address_standardizer-3": No such file or directory 
In database: app
```

As a workaround, pin `PostGIS` to `stable-3.6` until we have a solution.