### PR TITLE
ci: enable plugin-barman-cloud tests

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -12,6 +12,9 @@ on:
       feature_type:
         description: 'E2E feature type filter. See https://github.com/cloudnative-pg/cloudnative-pg/blob/main/contribute/e2e_testing_environment/README.md#using-feature-type-test-selectionfilter'
         required: false
+      barman_plugin:
+        description: 'plugin-barman-cloud version to install: release (default), main, or a pinned version like v0.12.0'
+        required: false
   schedule:
   - cron:  '0 1 * * *'
 
@@ -35,6 +38,7 @@ jobs:
       cnpg_branch: ${{ env.CNPG_BRANCH }}
       test_depth: ${{ env.TEST_DEPTH }}
       feature_type: ${{ env.FEATURE_TYPE }}
+      barman_plugin: ${{ env.BARMAN_PLUGIN }}
     steps:
     - name: Checkout Code
       uses: actions/checkout@v7
@@ -51,6 +55,7 @@ jobs:
         INPUT_CNPG_BRANCH: ${{ github.event.inputs.cnpg_branch }}
         INPUT_TEST_DEPTH: ${{ github.event.inputs.test_depth }}
         INPUT_FEATURE_TYPE: ${{ github.event.inputs.feature_type }}
+        INPUT_BARMAN_PLUGIN: ${{ github.event.inputs.barman_plugin }}
       run: |
         if [[ -n "${INPUT_CNPG_BRANCH}" ]]; then
           echo "CNPG_BRANCH=${INPUT_CNPG_BRANCH}" >> $GITHUB_ENV
@@ -60,6 +65,9 @@ jobs:
         fi
         if [[ -n "${INPUT_FEATURE_TYPE}" ]]; then
           echo "FEATURE_TYPE=${INPUT_FEATURE_TYPE}" >> $GITHUB_ENV
+        fi
+        if [[ -n "${INPUT_BARMAN_PLUGIN}" ]]; then
+          echo "BARMAN_PLUGIN=${INPUT_BARMAN_PLUGIN}" >> $GITHUB_ENV
         fi
 
     - name: Log in to the GitHub Container registry
@@ -105,3 +113,4 @@ jobs:
       cnpg_branch: ${{ needs.build-pg.outputs.cnpg_branch }}
       test_depth: ${{ needs.build-pg.outputs.test_depth }}
       feature_type: ${{ needs.build-pg.outputs.feature_type }}
+      barman_plugin: ${{ needs.build-pg.outputs.barman_plugin }}

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -138,11 +138,12 @@ jobs:
 
       - name: Setting up defaults
         run: |
-          # Exlude backup/recovery and image-volume tests
+          # Exclude backup/recovery and image-volume tests, but keep backup-restore
+          # tests that are also labeled plugin-barman-cloud
           if [ -z "${FEATURE_TYPE}" ]; then
-            echo "FEATURE_TYPE=!(backup-restore || image-volume-extensions)" >> $GITHUB_ENV
+            echo "FEATURE_TYPE=!((backup-restore && !plugin-barman-cloud) || image-volume-extensions)" >> $GITHUB_ENV
           else
-            echo "FEATURE_TYPE=!(backup-restore || image-volume-extensions) && ${FEATURE_TYPE}" >> $GITHUB_ENV
+            echo "FEATURE_TYPE=!((backup-restore && !plugin-barman-cloud) || image-volume-extensions) && ${FEATURE_TYPE}" >> $GITHUB_ENV
           fi
 
       - name: Run Kind End-to-End tests

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: string
         default: ""
+      barman_plugin:
+        description: 'plugin-barman-cloud version to install: release (default), main, or a pinned version like v0.12.0'
+        required: false
+        type: string
+        default: 'release'
 
 # set up environment variables to be used across all the jobs
 env:
@@ -47,6 +52,7 @@ jobs:
     env:
       TEST_DEPTH: ${{ inputs.test_depth }}
       FEATURE_TYPE: ${{ inputs.feature_type }}
+      BARMAN_PLUGIN_VERSION: ${{ inputs.barman_plugin }}
 
       POSTGRES_VERSION: ${{ inputs.major_version }}
       POSTGRES_IMG: ${{ inputs.postgres_img }}
@@ -58,7 +64,7 @@ jobs:
       DOCKER_USERNAME: ${{ github.actor }}
       DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
-      ID: "local"
+      ID: "kind"
       TEST_UPGRADE_TO_V1: false
       DEBUG: "true"
       BUILD_IMAGE: "true"
@@ -67,7 +73,7 @@ jobs:
       E2E_DEFAULT_VOLUMESNAPSHOT_CLASS: csi-hostpath-snapclass
       LOG_DIR: ${{ github.workspace }}/kind-logs/
       DOCKER_REGISTRY_MIRROR: https://mirror.gcr.io
-      TEST_CLOUD_VENDOR: "local"
+      TEST_CLOUD_VENDOR: "kind"
     steps:
       - name: Cleanup Disk
         uses: jlumbroso/free-disk-space@main
@@ -163,9 +169,11 @@ jobs:
         if: (always() && !cancelled())
         env:
           RUNNER: "${{ env.ID }}"
-          POSTGRES_VERSION: "${{ env.PG_MAJOR }}"
+          POSTGRES_VERSION: "${{ inputs.major_version }}"
+          POSTGRES_KIND: "${{ env.POSTGRES_KIND }}"
+          K8S_VERSION: "${{ env.K8S_VERSION }}"
           RUN_ID: "${{ github.run_id }}"
-          MATRIX: "${{ env.ID }}-${{ env.POSTGRES_KIND }}-${{ env.PG_MAJOR }}"
+          MATRIX: "${{ env.ID }}-${{ env.K8S_VERSION}}-${{ env.POSTGRES_KIND }}-${{ inputs.major_version }}"
           REPOSITORY: "${{ github.repository }}"
           BRANCH_NAME: "${GITHUB_REF#refs/heads/}"
           GIT_REF: "${{ github.ref_name }}"

--- a/.github/workflows/run-e2e-test.yml
+++ b/.github/workflows/run-e2e-test.yml
@@ -18,6 +18,9 @@ on:
       feature_type:
         description: 'E2E feature type filter. See https://github.com/cloudnative-pg/cloudnative-pg/blob/main/contribute/e2e_testing_environment/README.md#using-feature-type-test-selectionfilter'
         required: false
+      barman_plugin:
+        description: 'plugin-barman-cloud version to install: release (default), main, or a pinned version like v0.12.0'
+        required: false
 
 permissions: read-all
 
@@ -31,6 +34,7 @@ jobs:
       cnpg_branch: ${{ env.CNPG_BRANCH }}
       test_depth: ${{ env.TEST_DEPTH }}
       feature_type: ${{ env.FEATURE_TYPE }}
+      barman_plugin: ${{ env.BARMAN_PLUGIN }}
     steps:
     - name: Checkout Code
       uses: actions/checkout@v7
@@ -49,6 +53,7 @@ jobs:
         INPUT_CNPG_BRANCH: ${{ github.event.inputs.cnpg_branch }}
         INPUT_TEST_DEPTH: ${{ github.event.inputs.test_depth }}
         INPUT_FEATURE_TYPE: ${{ github.event.inputs.feature_type }}
+        INPUT_BARMAN_PLUGIN: ${{ github.event.inputs.barman_plugin }}
       run: |
         if [[ -n "${INPUT_POSTGRES_IMG}" ]]; then
           echo "PG_IMAGE=${INPUT_POSTGRES_IMG}" >> $GITHUB_ENV
@@ -65,6 +70,9 @@ jobs:
         if [[ -n "${INPUT_FEATURE_TYPE}" ]]; then
           echo "FEATURE_TYPE=${INPUT_FEATURE_TYPE}" >> $GITHUB_ENV
         fi
+        if [[ -n "${INPUT_BARMAN_PLUGIN}" ]]; then
+          echo "BARMAN_PLUGIN=${INPUT_BARMAN_PLUGIN}" >> $GITHUB_ENV
+        fi
 
   call-reusable-e2e:
     needs:
@@ -78,3 +86,4 @@ jobs:
       cnpg_branch: ${{ needs.evaluate-env.outputs.cnpg_branch }}
       test_depth: ${{ needs.evaluate-env.outputs.test_depth }}
       feature_type: ${{ needs.evaluate-env.outputs.feature_type }}
+      barman_plugin: ${{ needs.evaluate-env.outputs.barman_plugin }}

--- a/defaults.json
+++ b/defaults.json
@@ -3,5 +3,6 @@
   "PG_MAJOR": 19,
   "CNPG_BRANCH": "main",
   "TEST_DEPTH": 4,
-  "FEATURE_TYPE": ""
+  "FEATURE_TYPE": "",
+  "BARMAN_PLUGIN": "main"
 }

--- a/defaults.json
+++ b/defaults.json
@@ -4,5 +4,5 @@
   "CNPG_BRANCH": "main",
   "TEST_DEPTH": 4,
   "FEATURE_TYPE": "",
-  "BARMAN_PLUGIN": "main"
+  "BARMAN_PLUGIN": "release"
 }


### PR DESCRIPTION
In-tree Backup-recovery tests are skipped from this repository since we don't build system images here.
However plugin-barman-cloud tests can run with trunk minimal images, so we should enable them.