### PR TITLE
chore: sync CODEOWNERS with cnpg-infra policy

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,9 @@
-* @NiccoloFei @fcanovai @gbartolini @jbattiato @litaocdl @mnencia
+# This file is generated from componentowners-policy.yaml in
+# cloudnative-pg/cnpg-infra — do not hand-edit, propose changes there instead.
+#
+# Path-scoped rules below always include the repo's own general owners
+# (the "*" line) in addition to their own specific teams/users, since
+# CODEOWNERS only honors the LAST matching pattern for a given path —
+# it does not merge an earlier, less-specific rule into a later one.
+
+* @cloudnative-pg/postgres-trunk-containers-owners


### PR DESCRIPTION
Regenerates this repo's CODEOWNERS from cloudnative-pg/cnpg-infra's `componentowners-policy.yaml`, the org's tracked desired state for CODEOWNERS content.

- Routes ownership through this repo's dedicated GitHub owners team instead of hardcoded usernames, so membership changes are picked up automatically.
- Any path-scoped rule now also includes the repo's general owners, so a path rule adds reviewers rather than silently replacing the `*` rule's owners for that subtree (CODEOWNERS only honors the last matching pattern, it does not merge).

See cloudnative-pg/cnpg-infra for the policy this is generated from.

Assisted-by: Claude